### PR TITLE
Fixed deprecation for Symfony 4.2 / Symfony 5.0 Support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,8 +13,11 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sendinblue_api');
+        $treeBuilder = new TreeBuilder('sendinblue_api');
+
+        $rootNode = method_exists($treeBuilder, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('sendinblue_api');
 
         $rootNode
             ->beforeNormalization()
@@ -59,8 +62,11 @@ class Configuration implements ConfigurationInterface
      */
     private function getClientsNode()
     {
-        $treeBuilder = new TreeBuilder();
-        $node = $treeBuilder->root('clients');
+        $treeBuilder = new TreeBuilder('clients');
+
+        $node = method_exists($treeBuilder, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('clients');
 
         $node
             ->requiresAtLeastOneElement()

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
   "require": {
     "php": ">=5.4",
     "sendinblue/api-v3-sdk": ">=2 <6",
-    "symfony/config": "<5",
-    "symfony/dependency-injection": ">=2.6.2 <5",
-    "symfony/http-kernel": "<5"
+    "symfony/config": "<6",
+    "symfony/dependency-injection": ">=2.6.2 <6",
+    "symfony/http-kernel": "<6"
   },
   "require-dev": {
     "symfony/framework-bundle": ">=2.7.25",


### PR DESCRIPTION
- Fixed "A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0." deprecations (but kept support for older versions)